### PR TITLE
v2.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,5 +25,8 @@ mercurytools="mercurytools.cli.main:main"
 [tool.setuptools.packages.find]
 where=["src"]
 
+[tool.setuptools.package-data]
+mercurytools=["py.typed"]
+
 [tool.setuptools.dynamic]
 version={attr="mercurytools.__version__.__version__"}

--- a/src/mercurytools/cli/main.py
+++ b/src/mercurytools/cli/main.py
@@ -1,5 +1,11 @@
+"""entry point for the `mercurytools` console script."""
+
+
+from __future__ import annotations
+
 from mercurytools import __version__
 
 
-def main():
+def main() -> None:
+    """print the installed mercurytools version."""
     print(__version__)

--- a/src/mercurytools/core/base.py
+++ b/src/mercurytools/core/base.py
@@ -1,7 +1,18 @@
-class InternalStateGuard:
-    _protected_fields=frozenset()
+"""write-protection guard used by LinearBase and TreeBase.
+blocks assignment to any name listed in a subclass's _protected_fields
+from anywhere except the base class's own object.__setattr__ calls
+[see LinearBase/TreeBase's _set_* helpers].
+"""
 
-    def __setattr__(self,name,value):
+
+from __future__ import annotations
+from typing import Any, ClassVar, FrozenSet
+
+
+class InternalStateGuard:
+    _protected_fields:ClassVar[FrozenSet[str]]=frozenset()
+
+    def __setattr__(self,name:str,value:Any) -> None:
         if name in self._protected_fields:
             raise AttributeError(f"'{name}' is read-only; mutate via the public API")
         object.__setattr__(self,name,value)

--- a/src/mercurytools/core/base_linear.py
+++ b/src/mercurytools/core/base_linear.py
@@ -1,66 +1,74 @@
 """shared base class for doubly-linked sequential structures [LinkedList, Stack, Deque]."""
 
 
+from __future__ import annotations
+from typing import Generic, Iterable, Iterator, List, Optional, TypeVar, Union
+
 from .base import InternalStateGuard
 from .nodes import LinearNode as Node
 from .exceptions import EmptyStructureError,IndexOutOfBoundsError
 
+T=TypeVar("T")
 
-class LinearBase(InternalStateGuard):
+
+class LinearBase(InternalStateGuard,Generic[T]):
     """common state, iteration, indexing, and mutation helpers for linked sequences."""
     _protected_fields=frozenset({"_head","_tail","_size"})
+    _head:Optional[Node[T]]
+    _tail:Optional[Node[T]]
+    _size:int
 
-    def __init__(self):
+    def __init__(self) -> None:
         object.__setattr__(self,"_head",None)
         object.__setattr__(self,"_tail",None)
         object.__setattr__(self,"_size",0)
 
     @property
-    def head(self):
+    def head(self) -> Optional[Node[T]]:
         """the first node in the structure, or None if empty."""
         return self._head
     
     @property
-    def tail(self):
+    def tail(self) -> Optional[Node[T]]:
         """the last node in the structure, or None if empty."""
         return self._tail
     
     @property
-    def size(self):
+    def size(self) -> int:
         """number of elements currently stored."""
         return self._size
 
-    def __len__(self):
+    def __len__(self) -> int:
         return self._size
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[T]:
         """iterate over stored values from head to tail."""
         current=self._head
         while current:
             yield current.data
             current=current.next
 
-    def __reversed__(self):
+    def __reversed__(self) -> Iterator[T]:
         """iterate over stored values from tail to head."""
         current=self._tail
         while current:
             yield current.data
             current=current.prev
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.__class__.__name__}({list(self)})"
 
-    def __contains__(self,value):
+    def __contains__(self,value:T) -> bool:
         """return True if value is present, using == comparison: O(n)."""
         return any(item==value for item in self)
 
-    def __eq__(self,other):
+    def __eq__(self,other:object) -> bool:
         """two instances are equal if they hold the same values in the same order."""
         if not isinstance(other,LinearBase):
             return False
         return list(self)==list(other)
 
-    def __getitem__(self,index):
+    def __getitem__(self,index:Union[int,slice]) -> Union[T,"LinearBase[T]"]:
         """return the value at index, or a new instance for a slice."""
         if isinstance(index,slice):
             return self._slice(index)
@@ -71,7 +79,7 @@ class LinearBase(InternalStateGuard):
         return self._node_at(index).data
 
 
-    def _slice(self,s: slice):
+    def _slice(self,s:slice) -> "LinearBase[T]":
         """build a new instance of the same class from a slice of this one."""
         start,stop,step=s.indices(self._size)
         result=self.__class__()
@@ -82,12 +90,12 @@ class LinearBase(InternalStateGuard):
             i+=1
         return result
 
-    def extend(self,iterable):
+    def extend(self,iterable:Iterable[T]) -> None:
         """append every item from iterable, in order, to the end: O(n)."""
         for item in iterable:
             self._append_node(Node(item))
 
-    def pop(self,index=-1):
+    def pop(self,index:int=-1) -> T:
         """remove and return the value at index [default: the last element]."""
         if self._size==0:
             raise EmptyStructureError("pop from empty structure")
@@ -98,37 +106,43 @@ class LinearBase(InternalStateGuard):
         node=self._node_at(index)
         return self._remove_node(node)
 
-    def _node_at(self,index):
-        """return the node at index, walking from whichever end is closer."""
+    def _node_at(self,index:int) -> Node[T]:
+        """return the node at index, walking from whichever end is closer.
+
+        Caller must ensure 0 <= index < size.
+        """
         if index<self._size//2:
             current=self._head
             for _ in range(index):
+                assert current is not None
                 current=current.next
         else:
             current=self._tail
             for _ in range(self._size-index-1):
+                assert current is not None
                 current=current.prev
+        assert current is not None
         return current
 
 
-    def clear(self):
+    def clear(self) -> None:
         """remove all elements."""
         object.__setattr__(self,"_head",None)
         object.__setattr__(self,"_tail",None)
         object.__setattr__(self,"_size",0)
 
-    def to_list(self):
+    def to_list(self) -> List[T]:
         """return the stored values as a plain Python list, head to tail."""
         return list(self)
 
-    def copy(self):
+    def copy(self) -> "LinearBase[T]":
         """return a new, independent instance with the same values in the same order."""
         new=self.__class__()
         for item in self:
             new._append_node(Node(item))
         return new
 
-    def reverse(self):
+    def reverse(self) -> None:
         """reverse the structure in place. O(n), no new nodes allocated."""
         current=self._head
         object.__setattr__(self,"_head",self._tail)
@@ -137,34 +151,36 @@ class LinearBase(InternalStateGuard):
             current.next,current.prev=current.prev,current.next
             current=current.prev
 
-    def _set_size(self,value):
+    def _set_size(self,value:int) -> None:
         """set _size, bypassing the InternalStateGuard write-protection."""
         object.__setattr__(self,"_size",value)
 
 
-    def _append_node(self,node:Node):
+    def _append_node(self,node:Node[T]) -> None:
         """attach node as the new tail: O(1)."""
         if not self._head:
             object.__setattr__(self,"_head",node)
             object.__setattr__(self,"_tail",node)
         else:
+            assert self._tail is not None
             node.prev=self._tail
             self._tail.next=node
             object.__setattr__(self,"_tail",node)
         self._set_size(self._size+1)
 
-    def _prepend_node(self,node:Node):
+    def _prepend_node(self,node:Node[T]) -> None:
         """attach node as the new head: O(1)."""
         if not self._head:
             object.__setattr__(self,"_head",node)
             object.__setattr__(self,"_tail",node)
         else:
+            assert self._head is not None
             node.next=self._head
             self._head.prev=node
             object.__setattr__(self,"_head",node)
         self._set_size(self._size+1)
 
-    def _remove_node(self,node:Node):
+    def _remove_node(self,node:Node[T]) -> T:
         """unlink node from the structure and return its data: O(1)."""
         if node.prev:
             node.prev.next=node.next

--- a/src/mercurytools/core/base_tree.py
+++ b/src/mercurytools/core/base_tree.py
@@ -1,76 +1,83 @@
 """shared base class for binary tree structures [BinaryTree, BinarySearchTree, AVLTree]."""
 
 
+from __future__ import annotations
 from collections import deque
+from typing import Generic, Iterator, Optional, TypeVar
 
 from .base import InternalStateGuard
+from .nodes import BinaryTreeNode as Node
+
+T=TypeVar("T")
 
 
-class TreeBase(InternalStateGuard):
+class TreeBase(InternalStateGuard,Generic[T]):
     """common state and traversal methods shared by all binary tree types."""
     _protected_fields=frozenset({"_root","_size"})
+    _root:Optional[Node[T]]
+    _size:int
 
-    def __init__(self):
+    def __init__(self) -> None:
         object.__setattr__(self,"_root",None)
         object.__setattr__(self,"_size",0)
 
     @property
-    def size(self):
+    def size(self) -> int:
         """number of elements currently stored."""
         return self._size
 
     @property
-    def root(self):
+    def root(self) -> Optional[Node[T]]:
         """the root node, or None if the tree is empty."""
         return self._root
     
-    def __contains__(self,value):
+    def __contains__(self,value:T) -> bool:
         """return True if value is present: O(n) here; 
         overridden with O(h) in ordered trees.
         """
         return any(item==value for item in self)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[T]:
         """iterate over stored values in-order [left, node, right]: O(n) here; 
         overridden with O(h) in ordered trees.
         """
         return self.inorder()
 
-    def __len__(self):
+    def __len__(self) -> int:
         return self._size
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.__class__.__name__}({list(self.inorder())})"
     
 
-    def inorder(self):
+    def inorder(self) -> Iterator[T]:
         """yield values in-order: left subtree, node, right subtree."""
-        def _in(node):
+        def _in(node:Optional[Node[T]]) -> Iterator[T]:
             if node:
                 yield from _in(node.left)
                 yield node.data
                 yield from _in(node.right)
         return _in(self._root)
 
-    def preorder(self):
+    def preorder(self) -> Iterator[T]:
         """yield values pre-order: node, left subtree, right subtree."""
-        def _pre(node):
+        def _pre(node:Optional[Node[T]]) -> Iterator[T]:
             if node:
                 yield node.data
                 yield from _pre(node.left)
                 yield from _pre(node.right)
         return _pre(self._root)
 
-    def postorder(self):
+    def postorder(self) -> Iterator[T]:
         """yield values post-order: left subtree, right subtree, node."""
-        def _post(node):
+        def _post(node:Optional[Node[T]]) -> Iterator[T]:
             if node:
                 yield from _post(node.left)
                 yield from _post(node.right)
                 yield node.data
         return _post(self._root)
     
-    def level_order(self):
+    def level_order(self) -> Iterator[T]:
         """yield values breadth-first, level by level, top to bottom."""
         if not self._root:
             return
@@ -83,38 +90,38 @@ class TreeBase(InternalStateGuard):
             if current.right:
                 q.append(current.right)
 
-    def min(self):
+    def min(self) -> Optional[T]:
         """return the smallest value in the tree, or None if empty: O(n) here."""
         if self._size==0:
             return None
-        return min(self)
+        return min(self)  # type: ignore[type-var]
 
-    def max(self):
+    def max(self) -> Optional[T]:
         """return the largest value in the tree, or None if empty: O(n) here."""
         if self._size==0:
             return None
-        return max(self)
+        return max(self)  # type: ignore[type-var]
 
-    def height(self):
+    def height(self) -> int:
         """return the tree's height 
         -- an empty tree has height -1, a single node has height 0: O(n) here; 
         overridden with O(h) in ordered trees.
         """
-        def _height(node):
+        def _height(node:Optional[Node[T]]) -> int:
             if not node:
                 return -1
             return 1+max(_height(node.left),_height(node.right))
         return _height(self._root)
 
-    def clear(self):
+    def clear(self) -> None:
         """remove all elements"""
         object.__setattr__(self,"_root",None)
         object.__setattr__(self,"_size",0)
 
-    def _set_root(self,node):
+    def _set_root(self,node:Optional[Node[T]]) -> None:
         """set _root, bypassing the InternalStateGuard write-protection."""
         object.__setattr__(self,"_root",node)
 
-    def _set_size(self,value):
+    def _set_size(self,value:int) -> None:
         """set _size, bypassing the InternalStateGuard write-protection."""
         object.__setattr__(self,"_size",value)

--- a/src/mercurytools/core/comparable.py
+++ b/src/mercurytools/core/comparable.py
@@ -1,0 +1,17 @@
+"""structural typing helper for TypeVar bounds that require ordering [<, >].
+used by BinarySearchTree and AVLTree, whose stored values must support
+comparison for the tree to remain ordered. BinaryTree does not use
+this -- it has no ordering requirement.
+"""
+
+
+from __future__ import annotations
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Comparable(Protocol):
+    """structural type for anything supporting < and > comparisons."""
+
+    def __lt__(self,other:Any) -> bool: ...
+    def __gt__(self,other:Any) -> bool: ...

--- a/src/mercurytools/core/exceptions.py
+++ b/src/mercurytools/core/exceptions.py
@@ -3,6 +3,9 @@ all exceptions raised by this library inherit from MercuryError.
 """
 
 
+from __future__ import annotations
+
+
 class MercuryError(Exception):
     """base class for all exceptions raised by mercurytools."""
     pass
@@ -10,17 +13,17 @@ class MercuryError(Exception):
 
 class EmptyStructureError(MercuryError,IndexError):
     """raised when an operation requires at least one element but the structure is empty."""
-    def __init__(self,message="structure is empty"):
+    def __init__(self,message:str="structure is empty") -> None:
         super().__init__(message)
 
 
 class IndexOutOfBoundsError(MercuryError,IndexError):
     """raised when an index is outside the valid range for the structure."""
-    def __init__(self,message="index out of bounds"):
+    def __init__(self,message:str="index out of bounds") -> None:
         super().__init__(message)
 
 
 class ValueNotFoundError(MercuryError,ValueError):
     """raised when a value expected to exist in the structure could not be found."""
-    def __init__(self,message="value not found"):
+    def __init__(self,message:str="value not found") -> None:
         super().__init__(message)

--- a/src/mercurytools/core/nodes.py
+++ b/src/mercurytools/core/nodes.py
@@ -1,42 +1,50 @@
 """internal node types backing the linear and tree structures."""
 
 
-class LinearNode:
+from __future__ import annotations
+from typing import Generic, Optional, TypeVar
+
+T=TypeVar("T")
+K=TypeVar("K")
+V=TypeVar("V")
+
+
+class LinearNode(Generic[T]):
     """a doubly-linked node used by LinearBase-derived structures [LinkedList, Stack, Deque]."""
     __slots__=("data","next","prev")
 
-    def __init__(self,data):
-        self.data=data
-        self.next=None
-        self.prev=None
+    def __init__(self,data:T) -> None:
+        self.data:T=data
+        self.next:Optional[LinearNode[T]]=None
+        self.prev:Optional[LinearNode[T]]=None
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.data})"
 
 
-class LRUNode:
+class LRUNode(Generic[K,V]):
     """a doubly-linked key/value node used internally by LRUCache."""
     __slots__=("key","value","prev","next")
 
-    def __init__(self,key,value):
-        self.key=key
-        self.value=value
-        self.prev=None
-        self.next=None
+    def __init__(self,key:K,value:V) -> None:
+        self.key:K=key
+        self.value:V=value
+        self.prev:Optional[LRUNode[K,V]]=None
+        self.next:Optional[LRUNode[K,V]]=None
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.key}:{self.value})"
 
 
-class BinaryTreeNode:
+class BinaryTreeNode(Generic[T]):
     """a binary tree node used by BinaryTree, BinarySearchTree, and AVLTree."""
     __slots__=("data","left","right","height")
 
-    def __init__(self,data):
-        self.data=data
-        self.left=None
-        self.right=None
-        self.height=1
+    def __init__(self,data:T) -> None:
+        self.data:T=data
+        self.left:Optional[BinaryTreeNode[T]]=None
+        self.right:Optional[BinaryTreeNode[T]]=None
+        self.height:int=1
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.data})"

--- a/src/mercurytools/linear/deque.py
+++ b/src/mercurytools/linear/deque.py
@@ -1,32 +1,37 @@
 """double-ended queue backed by a doubly-linked list."""
 
 
+from __future__ import annotations
+from typing import TypeVar
+
 from ..core.base_linear import LinearBase
 from ..core.nodes import LinearNode as Node
 from ..core.exceptions import EmptyStructureError
 
+T=TypeVar("T")
 
-class Deque(LinearBase):
+
+class Deque(LinearBase[T]):
     """a double-ended queue with O(1) push/pop from either end.
     note: this overrides pop() with a no-argument version, which
     shadows LinearBase's indexed pop(index=-1).
     """
 
-    def append(self,data):
+    def append(self,data:T) -> None:
         """add data to the right end: O(1)."""
         self._append_node(Node(data))
 
-    def appendleft(self,data):
+    def appendleft(self,data:T) -> None:
         """add data to the left end: O(1)."""
         self._prepend_node(Node(data))
 
-    def pop(self):
+    def pop(self) -> T:  # type: ignore[override]
         """remove and return the rightmost element: O(1)."""
         if not self._tail:
             raise EmptyStructureError("pop from empty deque")
         return self._remove_node(self._tail)
 
-    def popleft(self):
+    def popleft(self) -> T:
         """remove and return the leftmost element: O(1)."""
         if not self._head:
             raise EmptyStructureError("pop from empty deque")

--- a/src/mercurytools/linear/linked_list.py
+++ b/src/mercurytools/linear/linked_list.py
@@ -1,23 +1,28 @@
 """doubly-linked list."""
 
 
+from __future__ import annotations
+from typing import TypeVar
+
 from ..core.base_linear import LinearBase
 from ..core.nodes import LinearNode as Node
 from ..core.exceptions import IndexOutOfBoundsError,ValueNotFoundError
 
+T=TypeVar("T")
 
-class LinkedList(LinearBase):
+
+class LinkedList(LinearBase[T]):
     """a doubly-linked list supporting O(1) append/prepend and indexed insert/remove."""
 
-    def append(self,data):
+    def append(self,data:T) -> None:
         """add data to the end: O(1)."""
         self._append_node(Node(data))
 
-    def prepend(self,data):
+    def prepend(self,data:T) -> None:
         """add data to the start: O(1)."""
         self._prepend_node(Node(data))
 
-    def insert(self,index,data):
+    def insert(self,index:int,data:T) -> None:
         """insert data before the element currently at index."""
         if index<0 or index>self._size:
             raise IndexOutOfBoundsError()
@@ -29,7 +34,9 @@ class LinkedList(LinearBase):
             return
         current=self._head
         for _ in range(index):
+            assert current is not None
             current=current.next
+        assert current is not None and current.prev is not None
         node=Node(data)
         node.prev=current.prev
         node.next=current
@@ -37,7 +44,7 @@ class LinkedList(LinearBase):
         current.prev=node
         self._set_size(self._size+1)
 
-    def remove(self,value):
+    def remove(self,value:T) -> T:
         """remove and return the first element equal to value."""
         current=self._head
         while current:

--- a/src/mercurytools/linear/priority_queue.py
+++ b/src/mercurytools/linear/priority_queue.py
@@ -1,12 +1,16 @@
 """binary min-heap priority queue, with an optional FIFO fallback mode."""
 
 
+from __future__ import annotations
+from typing import Any, Generic, Iterator, List, Optional, Tuple, TypeVar
+
 from ..core.exceptions import EmptyStructureError
 
+T=TypeVar("T")
 
-class PriorityQueue:
+
+class PriorityQueue(Generic[T]):
     """a binary min-heap that pops the lowest-priority value first.
-
     a single instance cannot mix priority andnon-priority pushes 
     -- whichever style is used first locks in the mode 
     for that instance's lifetime [until clear()].
@@ -14,27 +18,27 @@ class PriorityQueue:
     queue is stable.
     """
 
-    def __init__(self):
-        self._data=[]
-        self._uses_priority=None
-        self._counter=0
+    def __init__(self) -> None:
+        self._data:List[Tuple[Any,int,T]]=[]
+        self._uses_priority:Optional[bool]=None
+        self._counter:int=0
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._data)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.__class__.__name__}({[item[2] for item in self._data]})"
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[T]:
         """iterate over stored values in raw heap-array order [not priority order]."""
         for item in self._data:
             yield item[2]
 
-    def __contains__(self,value):
+    def __contains__(self,value:T) -> bool:
         """return True if value is present, using == comparison: O(n)."""
         return any(item[2]==value for item in self._data)
 
-    def __eq__(self,other):
+    def __eq__(self,other:object) -> bool:
         """two queues are equal if they'd pop in the same value sequence.
         compares both queues sorted by [priority, insertion order], so
         equal contents pushed in a different order still compare equal.
@@ -47,7 +51,7 @@ class PriorityQueue:
         other_sorted=sorted(other._data,key=lambda item:(item[0],item[1]))
         return [item[2] for item in self_sorted]==[item[2] for item in other_sorted]
 
-    def push(self,value,priority=None):
+    def push(self,value:T,priority:Optional[Any]=None) -> None:
         """push value with an optional priority [lower pops first]: O(log n)."""
         if self._uses_priority is None:
             self._uses_priority=priority is not None
@@ -61,7 +65,7 @@ class PriorityQueue:
         self._data.append(entry)
         self._heapify_up(len(self._data)-1)
 
-    def pop(self):
+    def pop(self) -> T:
         """remove and return the lowest-priority value."""
         if not self._data:
             raise EmptyStructureError("pop from empty priority queue")
@@ -70,47 +74,47 @@ class PriorityQueue:
         self._heapify_down(0)
         return value
 
-    def peek(self):
+    def peek(self) -> Optional[T]:
         """return the lowest-priority value without removing it, or None if empty: O(1)."""
         if not self._data:
             return None
         return self._data[0][2]
 
-    def to_list(self):
+    def to_list(self) -> List[T]:
         """return stored values as a plain list, in raw heap-array order [not priority order]."""
         return [item[2] for item in self._data]
 
-    def clear(self):
+    def clear(self) -> None:
         """remove all elements and reset priority mode, so push() can be used in either mode again."""
         self._data=[]
         self._uses_priority=None
         self._counter=0
 
-    def copy(self):
+    def copy(self) -> "PriorityQueue[T]":
         """return a new, independent queue with the same contents and priority mode."""
-        new=PriorityQueue()
+        new:PriorityQueue[T]=PriorityQueue()
         new._data=list(self._data)
         new._uses_priority=self._uses_priority
         new._counter=self._counter
         return new
 
 
-    def _priority(self,item):
+    def _priority(self,item:Tuple[Any,int,T]) -> Any:
         return item[0]
 
-    def _parent(self,i):
+    def _parent(self,i:int) -> int:
         return (i-1)//2
 
-    def _left(self,i):
+    def _left(self,i:int) -> int:
         return 2*i+1
 
-    def _right(self,i):
+    def _right(self,i:int) -> int:
         return 2*i+2
 
-    def _swap(self,i,j):
+    def _swap(self,i:int,j:int) -> None:
         self._data[i],self._data[j]=self._data[j],self._data[i]
 
-    def _heapify_up(self,i):
+    def _heapify_up(self,i:int) -> None:
         """restore the heap property by bubbling the item at index i upward."""
         while i>0:
             p=self._parent(i)
@@ -123,7 +127,7 @@ class PriorityQueue:
             except TypeError:
                 raise TypeError("values are not comparable for priority queue")
 
-    def _heapify_down(self,i):
+    def _heapify_down(self,i:int) -> None:
         """restore the heap property by sinking the item at index i downward."""
         size=len(self._data)
         while True:

--- a/src/mercurytools/linear/stack.py
+++ b/src/mercurytools/linear/stack.py
@@ -1,27 +1,32 @@
 """LIFO stack backed by a doubly-linked list."""
 
 
+from __future__ import annotations
+from typing import Optional, TypeVar
+
 from ..core.base_linear import LinearBase
 from ..core.nodes import LinearNode as Node
 from ..core.exceptions import EmptyStructureError
 
+T=TypeVar("T")
 
-class Stack(LinearBase):
+
+class Stack(LinearBase[T]):
     """a last-in-first-out stack with O(1) push/pop/peek.
     note: this overrides pop() with a no-argument LIFO version, which
     shadows LinearBase's indexed pop(index=-1).
     """
 
-    def push(self,data):
+    def push(self,data:T) -> None:
         """push data onto the top of the stack: O(1)."""
         self._append_node(Node(data))
 
-    def pop(self):
+    def pop(self) -> T:  # type: ignore[override]
         """remove and return the top element: O(1)."""
         if not self._tail:
             raise EmptyStructureError("pop from empty stack")
         return self._remove_node(self._tail)
 
-    def peek(self):
+    def peek(self) -> Optional[T]:
         """return the top element without removing it, or None if empty."""
         return None if not self._tail else self._tail.data

--- a/src/mercurytools/tree/avl_tree.py
+++ b/src/mercurytools/tree/avl_tree.py
@@ -1,19 +1,25 @@
 """self-balancing [AVL] binary search tree."""
 
 
+from __future__ import annotations
+from typing import Optional, Tuple, TypeVar
+
 from ..core.base_tree import TreeBase
 from ..core.nodes import BinaryTreeNode as Node
 from ..core.exceptions import ValueNotFoundError
+from ..core.comparable import Comparable
+
+T=TypeVar("T",bound=Comparable)
 
 
-class AVLTree(TreeBase):
+class AVLTree(TreeBase[T]):
     """a self-balancing binary search tree with guaranteed O(log n) insert/remove/lookup.
     after every insert/remove, the tree rebalances via single or double
     rotations [LL, RR, LR, RL] so that for any node, its two child
     subtrees' heights never differ by more than 1.
     """
 
-    def __contains__(self,value):
+    def __contains__(self,value:T) -> bool:
         """return True if value is present: O(log n)."""
         current=self._root
         while current:
@@ -25,11 +31,11 @@ class AVLTree(TreeBase):
                 return True
         return False
 
-    def insert(self,data):
+    def insert(self,data:T) -> None:
         """insert data, maintaining BST ordering and AVL balance: O(log n)."""
         self._set_root(self._insert(self._root,data))
 
-    def _insert(self,node,data):
+    def _insert(self,node:Optional[Node[T]],data:T) -> Node[T]:
         """recursively insert data into the subtree rooted at node and rebalance;
         returns the new subtree root.
         """
@@ -45,7 +51,7 @@ class AVLTree(TreeBase):
         self._update_height(node)
         return self._rebalance(node,data)
 
-    def remove(self,value):
+    def remove(self,value:T) -> T:
         """remove and return value, maintaining AVL balance: O(log n)."""
         new_root,deleted=self._remove(self._root,value)
         self._set_root(new_root)
@@ -54,7 +60,7 @@ class AVLTree(TreeBase):
             return value
         raise ValueNotFoundError(f"{value} not found")
 
-    def _remove(self,node,value):
+    def _remove(self,node:Optional[Node[T]],value:T) -> Tuple[Optional[Node[T]],bool]:
         """recursively remove value from the subtree rooted at node and rebalance;
         returns [new_subtree_root, was_deleted].
         """
@@ -75,59 +81,65 @@ class AVLTree(TreeBase):
         self._update_height(node)
         return self._rebalance_after_delete(node),deleted
 
-    def _min_node(self,node):
+    def _min_node(self,node:Node[T]) -> Node[T]:
         """return the leftmost [smallest] node in the subtree rooted at node."""
         while node.left:
             node=node.left
         return node
 
 
-    def _height(self,node):
+    def _height(self,node:Optional[Node[T]]) -> int:
         """return node's cached height, or 0 for None."""
         return node.height if node else 0
 
-    def _balance(self,node):
+    def _balance(self,node:Node[T]) -> int:
         """return node's balance factor: left subtree height minus right subtree height."""
         return self._height(node.left)-self._height(node.right)
 
-    def _update_height(self,node):
+    def _update_height(self,node:Node[T]) -> None:
         """recompute and store node's height from its children's cached heights."""
         node.height=1+max(self._height(node.left),self._height(node.right))
 
-    def _rebalance(self,node,data):
+    def _rebalance(self,node:Node[T],data:T) -> Node[T]:
         """apply the appropriate rotation [if any] after inserting data below node."""
         balance=self._balance(node)
-        if balance>1 and data<node.left.data:
-            return self._rotate_right(node)
-        if balance<-1 and data>node.right.data:
-            return self._rotate_left(node)
-        if balance>1 and data>node.left.data:
-            node.left=self._rotate_left(node.left)
-            return self._rotate_right(node)
-        if balance<-1 and data<node.right.data:
-            node.right=self._rotate_right(node.right)
-            return self._rotate_left(node)
-
+        if balance>1:
+            assert node.left is not None
+            if data<node.left.data:
+                return self._rotate_right(node)
+            if data>node.left.data:
+                node.left=self._rotate_left(node.left)
+                return self._rotate_right(node)
+        if balance<-1:
+            assert node.right is not None
+            if data>node.right.data:
+                return self._rotate_left(node)
+            if data<node.right.data:
+                node.right=self._rotate_right(node.right)
+                return self._rotate_left(node)
         return node
 
-    def _rebalance_after_delete(self,node):
+    def _rebalance_after_delete(self,node:Node[T]) -> Node[T]:
         """apply the appropriate rotation [if any] after a deletion below node."""
         balance=self._balance(node)
-        if balance>1 and self._balance(node.left)>=0:
-            return self._rotate_right(node)
-        if balance>1 and self._balance(node.left)<0:
+        if balance>1:
+            assert node.left is not None
+            if self._balance(node.left)>=0:
+                return self._rotate_right(node)
             node.left=self._rotate_left(node.left)
             return self._rotate_right(node)
-        if balance<-1 and self._balance(node.right)<=0:
-            return self._rotate_left(node)
-        if balance<-1 and self._balance(node.right)>0:
+        if balance<-1:
+            assert node.right is not None
+            if self._balance(node.right)<=0:
+                return self._rotate_left(node)
             node.right=self._rotate_right(node.right)
             return self._rotate_left(node)
         return node
 
 
-    def _rotate_left(self,z):
+    def _rotate_left(self,z:Node[T]) -> Node[T]:
         """left-rotate the subtree rooted at z; returns the new subtree root."""
+        assert z.right is not None
         y=z.right
         T2=y.left
         y.left=z
@@ -136,8 +148,9 @@ class AVLTree(TreeBase):
         self._update_height(y)
         return y
 
-    def _rotate_right(self,z):
+    def _rotate_right(self,z:Node[T]) -> Node[T]:
         """right-rotate the subtree rooted at z; returns the new subtree root."""
+        assert z.left is not None
         y=z.left
         T3=y.right
         y.right=z
@@ -146,7 +159,7 @@ class AVLTree(TreeBase):
         self._update_height(y)
         return y
     
-    def min(self):
+    def min(self) -> Optional[T]:
         """return the smallest value, or None if empty: O(log n)."""
         if not self._root:
             return None
@@ -155,7 +168,7 @@ class AVLTree(TreeBase):
             node=node.left
         return node.data
 
-    def max(self):
+    def max(self) -> Optional[T]:
         """return the largest value, or None if empty: O(log n)."""
         if not self._root:
             return None

--- a/src/mercurytools/tree/binary_search_tree.py
+++ b/src/mercurytools/tree/binary_search_tree.py
@@ -1,19 +1,25 @@
 """unbalanced binary search tree."""
 
 
+from __future__ import annotations
+from typing import Optional, Tuple, TypeVar
+
 from ..core.base_tree import TreeBase
 from ..core.nodes import BinaryTreeNode as Node
 from ..core.exceptions import ValueNotFoundError
+from ..core.comparable import Comparable
+
+T=TypeVar("T",bound=Comparable)
 
 
-class BinarySearchTree(TreeBase):
+class BinarySearchTree(TreeBase[T]):
     """a classic [unbalanced] binary search tree.
     insert/remove/__contains__ are O(h) where h is the tree's height --
     O(log n) on average, but O(n) in the worst case for adversarial or
     already-sorted insertion order.
     """
 
-    def __contains__(self,value):
+    def __contains__(self,value:T) -> bool:
         """return True if value is present: O(h)."""
         current=self._root
         while current:
@@ -26,7 +32,7 @@ class BinarySearchTree(TreeBase):
         return False
 
 
-    def _remove(self,node,value):
+    def _remove(self,node:Optional[Node[T]],value:T) -> Tuple[Optional[Node[T]],bool]:
         """recursively remove value from the subtree rooted at node.
         returns [new_subtree_root, was_deleted].
         """
@@ -49,14 +55,14 @@ class BinarySearchTree(TreeBase):
         node.right,deleted=self._remove(node.right,successor.data)
         return node,True
 
-    def _min_node(self,node):
+    def _min_node(self,node:Node[T]) -> Node[T]:
         """return the leftmost [smallest] node in the subtree rooted at node."""
         while node.left:
             node=node.left
         return node
 
 
-    def insert(self,data):
+    def insert(self,data:T) -> None:
         """insert data, maintaining BST ordering. Duplicate values are ignored: O(h)."""
         if not self._root:
             self._set_root(Node(data))
@@ -81,7 +87,7 @@ class BinarySearchTree(TreeBase):
             else:
                 return
 
-    def remove(self,value):
+    def remove(self,value:T) -> T:
         """remove and return value: O(h)."""
         new_root,deleted=self._remove(self._root,value)
         self._set_root(new_root)
@@ -90,7 +96,7 @@ class BinarySearchTree(TreeBase):
             return value
         raise ValueNotFoundError(f"{value} not found")
 
-    def min(self):
+    def min(self) -> Optional[T]:
         """return the smallest value, or None if empty: O(h)."""
         if not self._root:
             return None
@@ -99,7 +105,7 @@ class BinarySearchTree(TreeBase):
             node=node.left
         return node.data
 
-    def max(self):
+    def max(self) -> Optional[T]:
         """return the largest value, or None if empty: O(h)."""
         if not self._root:
             return None

--- a/src/mercurytools/tree/binary_tree.py
+++ b/src/mercurytools/tree/binary_tree.py
@@ -1,19 +1,23 @@
 """unordered binary tree with level-order [complete-tree] insertion."""
 
 
+from __future__ import annotations
 from collections import deque
+from typing import TypeVar
 
 from ..core.nodes import BinaryTreeNode as Node
 from ..core.base_tree import TreeBase
 
+T=TypeVar("T")
 
-class BinaryTree(TreeBase):
+
+class BinaryTree(TreeBase[T]):
     """a generic binary tree with no ordering guarantee between parent and children.
     insert() always fills the first available slot in level order 
     [i.e. keeps the tree "complete"].
     """
 
-    def insert(self,data):
+    def insert(self,data:T) -> None:
         """insert data into the first open slot found in level [breadth-first] order. O(n)."""
         new_node=Node(data)
         if not self._root:

--- a/src/mercurytools/utils/lru_cache.py
+++ b/src/mercurytools/utils/lru_cache.py
@@ -1,29 +1,35 @@
 """fixed-capacity LRU [least-recently-used] cache."""
 
 
+from __future__ import annotations
+from typing import Generic, Iterator, Optional, TypeVar
+
 from ..core.nodes import LRUNode as Node
 
+K=TypeVar("K")
+V=TypeVar("V")
 
-class LRUCache:
+
+class LRUCache(Generic[K,V]):
     """a fixed-capacity key/value cache that evicts the least recently used entry.
     both get() and put() count as "use" and move the entry to the front.
     Backed by a hash map [O(1) lookup] plus a doubly-linked list [O(1)
     reordering and eviction].
     """
 
-    def __init__(self,capacity:int):
+    def __init__(self,capacity:int) -> None:
         """create a cache holding at most capacity entries."""
         if capacity<=0:
             raise ValueError("capacity must be greater than 0")
-        self._capacity=capacity
-        self._map={}
-        self._head=None
-        self._tail=None
+        self._capacity:int=capacity
+        self._map:dict[K,Node[K,V]]={}
+        self._head:Optional[Node[K,V]]=None
+        self._tail:Optional[Node[K,V]]=None
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._map)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         items=[]
         current=self._head
         while current:
@@ -32,7 +38,7 @@ class LRUCache:
         return f"LRUCache({items})"
 
 
-    def get(self,key):
+    def get(self,key:K) -> Optional[V]:
         """return the value for key and mark it most recently used, or None if absent: O(1)."""
         node=self._map.get(key)
         if not node:
@@ -40,7 +46,7 @@ class LRUCache:
         self._move_to_head(node)
         return node.value
 
-    def put(self,key,value):
+    def put(self,key:K,value:V) -> None:
         """insert or update key with value, marking it most recently used.
         if this insertion exceeds capacity, the least recently used
         entry is evicted: O(1).
@@ -56,20 +62,20 @@ class LRUCache:
         if len(self._map)>self._capacity:
             self._evict()
 
-    def clear(self):
+    def clear(self) -> None:
         """remove all entries."""
         self._map.clear()
         self._head=None
         self._tail=None
 
-    def keys(self):
+    def keys(self) -> Iterator[K]:
         """yield keys from most to least recently used."""
         current=self._head
         while current:
             yield current.key
             current=current.next
 
-    def values(self):
+    def values(self) -> Iterator[V]:
         """yield values from most to least recently used."""
         current=self._head
         while current:
@@ -77,7 +83,7 @@ class LRUCache:
             current=current.next
 
 
-    def _add_to_head(self,node):
+    def _add_to_head(self,node:Node[K,V]) -> None:
         """insert node at the front [most recently used position]: O(1)."""
         node.prev=None
         node.next=self._head
@@ -87,7 +93,7 @@ class LRUCache:
         if not self._tail:
             self._tail=node
 
-    def _remove_node(self,node):
+    def _remove_node(self,node:Node[K,V]) -> None:
         """unlink node from the list without touching the key map: O(1)."""
         if node.prev:
             node.prev.next=node.next
@@ -98,12 +104,12 @@ class LRUCache:
         else:
             self._tail=node.prev
 
-    def _move_to_head(self,node):
+    def _move_to_head(self,node:Node[K,V]) -> None:
         """move an already-linked node to the front: O(1)."""
         self._remove_node(node)
         self._add_to_head(node)
 
-    def _evict(self):
+    def _evict(self) -> None:
         """remove the least recently used entry (the tail) from both the list and the map: O(1)."""
         if not self._tail:
             return


### PR DESCRIPTION
**mercurytools [v2.3.0]**


### **changelog:**

_added Generic[T] (K/V for LRUCache) type hints across the entire_
_public and private API, using `from __future__ import annotations` so annotations are lazy strings -- zero runtime cost._ 

_added core/comparable.py: a structural Comparable protocol used to bound BinarySearchTree/AVLTree's TypeVar, since their stored values must support < and > for the tree to stay ordered. BinaryTree is unordered and has no such bound._

_declared `_head/_tail/_size/_root` as typed class-level attributes on LinearBase/TreeBase so mypy can see them despite being set via `object.__setattr__` [bypassing InternalStateGuard]._